### PR TITLE
Added knockpy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -86,9 +86,7 @@ install_sublist3r(){
 
 install_knockpy(){
     echo "Installing Knockpy"
-    git clone https://github.com/guelfoweb/knock
-    sudo mv knock/ /opt/
-    pip3 install -r /opt/knock/requirements.txt
+    sudo apt install knockpy
     echo "Done!";
 }
 

--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,14 @@ install_sublist3r(){
     echo "Done!";
 }
 
+install_knockpy(){
+    echo "Installing Knockpy"
+    git clone https://github.com/guelfoweb/knock
+    sudo mv knock/ /opt/
+    sudo python3 setup.py install 
+    echo "Done!";
+}
+
 install_amass(){
     echo "Installing Amass!"
     sudo snap install amass
@@ -333,13 +341,6 @@ install_dirdar(){
     echo "Done!";
 }
 
-install_knockpy(){
-    echo "Installing Knockpy"
-    git clone https://github.com/guelfoweb/knock
-    sudo mv knock/ /opt/
-    sudo python3 setup.py install 
-    echo "Done!";
-}
 
 main(){
     uninstall_mandb
@@ -360,6 +361,7 @@ main(){
 
     sourcee
     install_sublist3r
+    install_knockpy
     install_amass
     install_lazys3
     install_gospider
@@ -390,7 +392,6 @@ main(){
     install_rustc
     install_hydra
     install_dirdar
-    install_knockpy
 }
 
 main

--- a/install.sh
+++ b/install.sh
@@ -333,6 +333,13 @@ install_dirdar(){
     echo "Done!";
 }
 
+install_knockpy(){
+    echo "Installing Knockpy"
+    git clone https://github.com/guelfoweb/knock
+    sudo mv knock/ /opt/
+    sudo python3 setup.py install 
+    echo "Done!";
+}
 
 main(){
     uninstall_mandb
@@ -383,6 +390,7 @@ main(){
     install_rustc
     install_hydra
     install_dirdar
+    install_knockpy
 }
 
 main

--- a/install.sh
+++ b/install.sh
@@ -88,8 +88,7 @@ install_knockpy(){
     echo "Installing Knockpy"
     git clone https://github.com/guelfoweb/knock
     sudo mv knock/ /opt/
-    pip3 install -r /opt/knock/requirements.txt
-    sudo ln -sfv /opt/knock/knockpy/knockpy.py /usr/local/bin/knockpy
+    python3 /opt/knock/setup.py install
     echo "Done!";
 }
 

--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,7 @@ install_knockpy(){
     echo "Installing Knockpy"
     git clone https://github.com/guelfoweb/knock
     sudo mv knock/ /opt/
-    python3 /opt/knock/setup.py install
+    pip3 install -r /opt/knock/requirements.txt
     echo "Done!";
 }
 

--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,8 @@ install_knockpy(){
     echo "Installing Knockpy"
     git clone https://github.com/guelfoweb/knock
     sudo mv knock/ /opt/
-    sudo python3 setup.py install 
+    pip3 install -r /opt/knock/requirements.txt
+    sudo ln -sfv /opt/knock/knockpy/knockpy.py /usr/local/bin/knockpy
     echo "Done!";
 }
 


### PR DESCRIPTION
Changes:
made a new function to install knockpy and called to the main function

code:

```
install_knockpy(){
    echo "Installing Knockpy"
    sudo apt install knockpy
    echo "Done!";
}
```
Impact: Able to enumerate subdomain with updated python3 supported too